### PR TITLE
Updated IaC based on proposals. Python 3.6 is no longer supported.

### DIFF
--- a/devops_standards.md
+++ b/devops_standards.md
@@ -28,13 +28,13 @@ The use of **obsolete** will be denoted when something is no longer part of the 
 - TFS (**obsolete**)
 
 ## Languages
-- Python >3.7
+- Python >= 3.7
 - .NET (C#) >6
 - Ruby
 - Javascript >6
 - Typescript
 - .NET <6 (C#)(**deprecated**)
-- Python <2 (**deprecated**)
+- Python <3.7 (**deprecated**)
 - Javascript <6 (**deprecated**)
 - Rust (**obsolete**)
 - DNX (**obsolete**)
@@ -64,7 +64,7 @@ The use of **obsolete** will be denoted when something is no longer part of the 
 ## Logging
 - Cloudwatch
 - App Insights
-- DataDog (investigating)
+- DataDog (**obsolete**)
 - Graylog (**obsolete**) :fire:
 
 ## Exception Reporting
@@ -78,9 +78,9 @@ The use of **obsolete** will be denoted when something is no longer part of the 
 - Grafana
 
 ## Infrastructure As Code
-- Terraform
+- Terraform (**deprecated**)
 - Pulumi
-- Serverless
+- Serverless (**deprecated**)
 - Azure Resource Manager (?)
 - Ansible (**deprecated**)
 


### PR DESCRIPTION
Updated the IaC based on proposal to use Pulumi as the primary tool.  Python 3.6 is deprecated and no longer supported by the community for patches and security updates. 