### PR TITLE
Add video to template and remove "Anything else"

### DIFF
--- a/templates/pull_request_template.md
+++ b/templates/pull_request_template.md
@@ -11,8 +11,5 @@
 ## Testing
 (what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes)
 
-## Screenshots (if applicable)
+## Screenshots/Video
 (show before/after of the change if possible)
-
-## Anything else 
-(lingering questions/concerns/learning)


### PR DESCRIPTION
## Purpose 
Adding "Video" to screenshot to encourage the use of video as demonstration.

Removing "Anything Else" from the template, because it isn't a sufficient prompt (and people can always add things).

## Approach 
Editing the file. 

## Testing
Testing is this PR - if it is acceptable, then it passes the test :)

## Screenshots/Video
<img width="1140" alt="Screen Shot 2022-10-19 at 11 54 58 AM" src="https://user-images.githubusercontent.com/2671/196742818-0acd94bc-561c-47df-a12f-815fa91bf199.png">
