### PR TITLE
Add confluence/documentation section to README

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -140,3 +140,7 @@ py manage.py runserver
 ```
 
 > Code owners can be found in [CODEOWNERS file](./CODEOWNERS)
+
+## Confluence Links
+
+A place to link confluence pages/documentation related to the application (until it is moved to git wiki or README).

--- a/templates/README.md
+++ b/templates/README.md
@@ -141,6 +141,6 @@ py manage.py runserver
 
 > Code owners can be found in [CODEOWNERS file](./CODEOWNERS)
 
-## Confluence Links
+## Confluence/Documentation Links
 
 A place to link confluence pages/documentation related to the application (until it is moved to git wiki or README).

--- a/templates/README.md
+++ b/templates/README.md
@@ -141,6 +141,6 @@ py manage.py runserver
 
 > Code owners can be found in [CODEOWNERS file](./CODEOWNERS)
 
-## Confluence/Documentation Links
+## Confluence/Documentation Links (optional)
 
 A place to link confluence pages/documentation related to the application (until it is moved to git wiki or README).


### PR DESCRIPTION
Add confluence section to README template

## Purpose 
Currently, lots of our legacy applications contain documentation that is spread across multiple confluence spaces. Teams leave and confluence spaces get abandoned, new teams come and new confluence spaces get created.

This section is just a suggestion to help gather all that information in one place, so that all information related to the application is collected in one place (Github).

For newer applications, this section could still be useful for linking their documentation wherever it is stored.

## Approach 
N/A

## Testing
N/A

## Screenshots/Video
N/A