### PR TITLE
BEL-1208 Add standard for alerting on 5xx errors

### DIFF
--- a/box_of_autonomy.md
+++ b/box_of_autonomy.md
@@ -100,3 +100,4 @@ Each team/product will produce/publish/follow the following:
 - Exceptions must be reported to an approved exception reporting system.
 - Data must be shipped to the data platform.
 - Data retention matches corporate policy.
+- 500-599 error codes returned from a service outside a normal anomaly band should alert the development team and the dev/ops team.


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-1208)

## Purpose 
As part of the follow up to an outage, we were asked to come up with a standard for alerts when services are returning errors.

## Approach 
We took a look at the existing services and the alarms that have been setup. For ID Mapper, we used an anomaly band on 5xx errors and it is successfully alerting us when we get spikes of errors. We are using this as the basis for our standard. Most of the other services had insufficient or broken alarms.

## Testing
n/a
