### PR TITLE
(S) QTY-4826: add approved gems to the devops_standards and link to original passed proposal

### DIFF
--- a/devops_standards.md
+++ b/devops_standards.md
@@ -46,6 +46,11 @@ The use of **obsolete** will be denoted when something is no longer part of the 
 - Rust (**obsolete**)
 - DNX (**obsolete**)
 
+## Ruby Gems
+- [simple_calendar](https://rubygems.org/gems/simple_calendar): frontend calendar
+- [rolify](https://rubygems.org/gems/rolify): role management
+- [pundit](https://rubygems.org/gems/pundit): authorization
+
 ## Video/Audio/Chat Conferencing
 - Zoom
 - Slack

--- a/engineering_leadership/passed_proposals/2023_10.md
+++ b/engineering_leadership/passed_proposals/2023_10.md
@@ -5,6 +5,7 @@
 with @qwerty-talk doing some work with calendars in smc pretty soon, i think it's time we decide on a standard for calendar gems. it seems like there's one gem  with 2.6 million downloads called simple_calendar, written by Chris Oliver and regularly maintained. there are others here but they're not regularly maintained or don't give us what we need.
 simple_calendar is  easy to implement and can render events based off active records like sessions. it also provides a generator for the calendar views so we can style them to meet our needs. example implementation video.
 i propose we choose simple_calendar as the standard rails gem for implementing frontend calendars. 3.2.1
+[slack proposal](https://flipswitch.slack.com/archives/C02GC9LSTFT/p1696267776997689)
 
 #### Author
 Angel Diaz


### PR DESCRIPTION
…riginal proposal in passed proposal

[QTY-4826](https://strongmind.atlassian.net/browse/QTY-4826)

## Purpose 
update the culture repo with updated passed proposal

## Approach 
n/a

## Testing
n/a

## Screenshots/Video
n/a

[QTY-4826]: https://strongmind.atlassian.net/browse/QTY-4826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ