### PR TITLE
(S) SKNK-4470 - Add upmark gem to gems.md list

### DIFF
--- a/gems.md
+++ b/gems.md
@@ -152,6 +152,7 @@
 - [require_all](https://rubygems.org/gems/require_all): A wonderfully simple way to load your code.
 - [rails-erd](https://rubygems.org/gems/rails-erd): Generate Entity-Relationship Diagrams for your Rails application.
 - [net-sftp](https://rubygems.org/gems/net-sftp): Secure File Transfer Protocol (SFTP) library.
+- [upmark](https://github.com/conversation/upmark): A HTML to Markdown converter.
 - [multi_json](https://rubygems.org/gems/multi_json): A gem to provide simple JSON parsing and encoding.
 - [ed25519](https://rubygems.org/gems/ed25519): Ruby bindings to the Ed25519 digital signature algorithm.
 - [cloud_events](https://rubygems.org/gems/cloud_events): Ruby implementation of CloudEvents.


### PR DESCRIPTION
[SKNK-4470](https://strongmind.atlassian.net/browse/SKNK-4470)

## Purpose 
We need an HTML to Markup converter.

The specific problem this is solving (in Course Builder):
Learnosity only accepts HTML to format content.  We sync back content from Learnosity to Course Builder to make it searchable through Algolia.  We do not want to store HTML.

## Approach 
Add gem to approved gems list

[slack approval thread](https://flipswitch.slack.com/archives/C02GC9LSTFT/p1726101493841389)

## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->

## Screenshots/Video
<!-- show before/after of the change if possible -->


[SKNK-4470]: https://strongmind.atlassian.net/browse/SKNK-4470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ