### PR TITLE
KAPE-4776 Adds acts_as_list to list of approved gems

### DIFF
--- a/gems.md
+++ b/gems.md
@@ -160,6 +160,7 @@
 - [acts-as-taggable-on](https://rubygems.org/gems/acts-as-taggable-on): Tagging functionality for your Rails application.
 - [langchainrb](https://rubygems.org/gems/langchainrb/versions/0.17.1): For building LLM-powered applications in Ruby
 - [metainspector](https://rubygems.org/gems/metainspector): Lets you scrape a web page and get its links, images, texts, meta tags...
+- [acts_as_list](https://rubygems.org/gems/acts_as_list) "acts_as" extension which provides the capabilities of sorting and reordering objects in a list
 - paper_trail (**deprecated**)
 - capistrano-rbenv (**deprecated**)
 - capistrano-rails (**deprecated**)


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/KAPE-4776)

## Purpose 
To use the gem for sorting or reordering resources in SMC

## Approach 
Proposed by @ataruc2022

## Testing
n/a

## Screenshots/Video
n/a
