### PR TITLE
Add ruby-lsp to approved gems

### DIFF
--- a/gems.md
+++ b/gems.md
@@ -167,6 +167,7 @@
 - [metainspector](https://rubygems.org/gems/metainspector): Lets you scrape a web page and get its links, images, texts, meta tags...
 - [acts_as_list](https://rubygems.org/gems/acts_as_list) "acts_as" extension which provides the capabilities of sorting and reordering objects in a list
 - [pdf-reader](https://rubygems.org/gems/pdf-reader) implements a PDF parser conforming as much as possible to the PDF specification from Adobe
+- [ruby-lsp](https://github.com/Shopify/ruby-lsp) Language Server Protocol implementation for Ruby
 - paper_trail (**deprecated**)
 - capistrano-rbenv (**deprecated**)
 - capistrano-rails (**deprecated**)


### PR DESCRIPTION
Via [this](https://flipswitch.slack.com/archives/C02GC9LSTFT/p1738095320485109) passed proposal for [ruby-lsp](https://github.com/Shopify/ruby-lsp)