### PR TITLE
Add Go and React/TypeScript standards to devops_standards.md

### DIFF
--- a/devops_standards.md
+++ b/devops_standards.md
@@ -38,7 +38,9 @@ The use of **obsolete** will be denoted when something is no longer part of the 
 - .NET (C#) >6
 - Ruby >3
 - Javascript >6
-- Typescript
+- Typescript >= 5
+- Go >= 1.25
+- Node.js >= 20
 - .NET <6 (C#)(**deprecated**)
 - Ruby <3 (**deprecated**)
 - Python <3.8 (**deprecated**)
@@ -57,7 +59,7 @@ The use of **obsolete** will be denoted when something is no longer part of the 
 
 
 ## Front End Frameworks
-- React
+- React >= 18 (>=19 default for new work)
 - Ionic
 - Blazor
 - Next.JS
@@ -135,6 +137,8 @@ The use of **obsolete** will be denoted when something is no longer part of the 
 ## Testing Tools
 - PyTest Describe (Python)
 - Jest (Javascript)
+- Vitest (Javascript/Typescript)
+- go test + testify (Go)
 - Rspec (Ruby)
 - xUnit (.NET)
 - nUnit (.NET)
@@ -150,6 +154,7 @@ The use of **obsolete** will be denoted when something is no longer part of the 
 - rbenv (ruby)
 - venv (python)
 - nvm (node)
+- Volta (node)
 
 ## Package Management
 - pypi.org (python)
@@ -158,6 +163,11 @@ The use of **obsolete** will be denoted when something is no longer part of the 
 - nuget.org (.net)
   - Package ID prefix "SM."
 - rubygems.org (ruby)
+- go modules (go)
+  - `github.com/StrongMind/strongmind-platform/go`, consumed via `go get`
+  - Versioned by path-prefixed git tags (`go/vX.Y.Z`), not a central registry (see ADR-0002)
+- GitHub Packages (javascript/typescript)
+  - `@strongmind/*` scoped packages, consumed by version, never by repo path (see ADR-0002)
 
 ## Web Packaging (npm, yarn, etc)
 - npm


### PR DESCRIPTION
## Why

`devops_standards.md` has no Go entries at all, and its React/TS entries have no version floors, even though Go and React/TS are now StrongMind's primary backend/frontend direction (Ruby on Rails being phased out). This fills in the gaps we have confirmation on; a couple of items are intentionally left out (see below).

## Changes

- **Languages**: add `Go >= 1.25`, add `Node.js >= 20`, version-floor the existing bare `Typescript` line to `Typescript >= 5`
- **Front End Frameworks**: version-floor `React` to `React >= 18 (>=19 default for new work)`
- **Testing Tools**: add `go test + testify (Go)`, add `Vitest (Javascript/Typescript)` alongside the existing `Jest` entry
- **Package Management**: add a `go modules` entry (consumed via `go get` from `github.com/StrongMind/strongmind-platform/go`, versioned by path-prefixed git tags, not a central registry) and a `GitHub Packages` entry for `@strongmind/*` scoped JS/TS packages
- **Virtual Environment Manager**: add `Volta (node)` alongside the existing `nvm (node)`

## Sources

- Version floors (Go 1.25, React 18/19, TS 5, Node 20) confirmed by Rui Costa, Principal Engineering. Go 1.25: all Go repos plus the shared module and CI run 1.25+, Campus already on 1.26.
- Go/JS-TS package management: [ADR-0002, Consistent Tech Stack](https://github.com/StrongMind/strongmind-platform/blob/main/docs/adr/ADR-0002-consistent-tech-stack.md) (Accepted)
- Testing tools and Volta verified directly against `strongmind-attendance` (`go.mod`, `go test`/`testify` usage) and `StrongMind/homeschool` (`web/package.json`: Vitest, Volta pin)

## Deliberately not included

Front End Frameworks doesn't get a new meta-framework entry (e.g. "TanStack Start") in this PR. [ADR-0013](https://github.com/StrongMind/strongmind-platform/blob/main/docs/adr/ADR-0013-bff-for-browser-app-authentication.md) (Proposed) names TanStack Start as the assumed frontend stack, but `homeschool/web`'s actual `package.json` shows React Router v7 + TanStack Query with no TanStack Start dependency. That's a real discrepancy between the ADR and the reference app's code, not just a naming choice, so it needs its own confirmation (cc whoever owns ADR-0013) before we commit a specific meta-framework name to this doc.

Opened as a draft for review before merging.